### PR TITLE
Add inference metrics script and update README with performance data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,26 @@ What is generative AI? Read on to learn what that means, and how it could change
 [Extend]  => 20 tokens, throughput: 8.31 tokens/s
 ```
 
-Measure performance metrics
+## Measure performance metrics
+
+Python
 
 ```sh
-poetry run python ./inference-metrics.py -n 5 -- poetry run python ./openai-gpt2/python-generate.py --max-length=106 "What is generative AI?"
+poetry run python ./inference-metrics.py --warm 3 -n 5 -- poetry run python ./openai-gpt2/python-generate.py --max-length=106 "What is generative AI?"
+...
+
+Average Metrics:
+[Prompt]  => 6 tokens, latency (TTFT): 0.29 ms
+[Extend]  => 100 tokens, throughput: 44.93 tokens/s
+```
+
+Swift
+
+```
+poetry run python ./inference-metrics.py --warm 3 -n 5 -- swift run --package-path ./CoreMLRunner -- coreml-runner --max-length=106 "What is generative AI?"
+...
+
+Average Metrics:
+[Prompt]  => 6 tokens, latency (TTFT): 0.15 ms
+[Extend]  => 100 tokens, throughput: 9.03 tokens/s
 ```


### PR DESCRIPTION
This PR introduces a new Python script for measuring inference metrics and updates the README with performance data for both Python and Swift implementations.

Main changes:
1. Added `inference-metrics.py` script to measure and analyze inference performance
2. Updated README.md with new sections for Swift implementation and performance metrics

The `inference-metrics.py` script:
- Runs a specified program multiple times to collect inference metrics
- Measures prompt tokens, Time To First Token (TTFT), generated tokens, and throughput
- Calculates and displays average metrics across multiple runs
- Supports warm-up iterations and customizable number of runs

README updates:
- Added Swift implementation example with sample output
- Included new section "Measure performance metrics" with examples for both Python and Swift
- Displayed average metrics for token count, TTFT, and throughput

This change allows for easier comparison of inference performance between different implementations and provides a standardized way to measure and report metrics.

```python
# Example usage of inference-metrics.py
poetry run python ./inference-metrics.py --warm 3 -n 5 -- YOUR_COMMAND_HERE
```

The script can be used with both Python and Swift implementations, facilitating consistent performance measurement across different language environments.