### PR TITLE
Add option to toggle KV cache usage in Python GPT-2 generation script

### DIFF
--- a/openai-gpt2/python-generate.py
+++ b/openai-gpt2/python-generate.py
@@ -50,7 +50,12 @@ class PerformanceMetricsStreamer(TextStreamer):
     default=100,
     help="The maximum number of tokens to generate.",
 )
-def main(prompt, max_length):
+@click.option(
+    "--use-cache/--no-use-cache",
+    default=True,
+    help="Whether to use KV cache during generation.",
+)
+def main(prompt, max_length, use_cache):
     tokenizer = GPT2Tokenizer.from_pretrained(
         "gpt2", clean_up_tokenization_spaces=False
     )
@@ -72,6 +77,7 @@ def main(prompt, max_length):
         max_new_tokens=max_new_tokens,
         do_sample=True,
         pad_token_id=tokenizer.eos_token_id,
+        use_cache=use_cache,
     )
 
     # Example output:


### PR DESCRIPTION
This PR introduces a new command-line option to control the usage of KV cache during text generation in the Python GPT-2 script.

Main changes:
- Added a new `--use-cache/--no-use-cache` option to the `main` function
- Modified the `generate` function call to include the `use_cache` parameter

The new option allows users to toggle the KV cache usage, which can be useful for performance testing or debugging. By default, the cache is enabled (`use_cache=True`).

Implementation details:
- The `main` function signature has been updated to include the `use_cache` parameter
- A new `click.option` decorator has been added to handle the command-line argument
- The `generate` function call now includes `use_cache=use_cache` to pass the user's preference

Example usage:
```
python python-generate.py --prompt "Your prompt here" --max-length 100 --no-use-cache
```