### PR TITLE
Add minimum deployment target option for GPT-2 export

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,22 @@ iPhone using CoreML. I’m particularly interested in taking advantage of the Ap
 (ANE) to make the models as fast and efficient as possible. I’m also experimenting with ways to
 optimize LLMs for iPhone.
 
-## Models
-
-### Llama
+## Llama
 
 ```sh
 $ poetry run python ./llama/export-model.py
 $ poetry run python ./llama/predict.py
 ```
 
-### GPT-2
+## GPT-2
+
+### Export model
+
+```sh
+$ poetry run python ./openai-gpt2/export-model.py --context-size 1024 --minimum-deployment-target iOS18
+```
+
+### Inference
 
 Python
 

--- a/openai-gpt2/export-model.py
+++ b/openai-gpt2/export-model.py
@@ -10,6 +10,15 @@ batch_size = 1
 context_size = 1024
 input_shape = (batch_size, context_size)
 
+DEPLOYMENT_TARGETS = {
+    "iOS13": ct.target.iOS13,
+    "iOS14": ct.target.iOS14,
+    "iOS15": ct.target.iOS15,
+    "iOS16": ct.target.iOS16,
+    "iOS17": ct.target.iOS17,
+    "iOS18": ct.target.iOS18,
+}
+
 
 class BaselineGPT2LMHeadModel(GPT2LMHeadModel):
     """Baseline LlamaForCausalLM model without key/value caching."""
@@ -36,12 +45,18 @@ class BaselineGPT2LMHeadModel(GPT2LMHeadModel):
     type=int,
 )
 @click.option(
+    "--minimum-deployment-target",
+    default="iOS16",
+    help="Minimum deployment target (iOS13-iOS18).",
+    type=click.Choice(list(DEPLOYMENT_TARGETS.keys())),
+)
+@click.option(
     "--output",
     default="models/GPT2Model.mlpackage",
     help="Output path for the Core ML model.",
     type=click.Path(),
 )
-def main(context_size: int, output: str):
+def main(context_size: int, minimum_deployment_target: str, output: str):
     """Convert GPT-2 PyTorch model to Core ML format."""
     model_id = "gpt2"
     batch_size = 1
@@ -70,7 +85,7 @@ def main(context_size: int, output: str):
         traced_model,
         inputs=inputs,
         outputs=outputs,
-        minimum_deployment_target=ct.target.macOS13,
+        minimum_deployment_target=DEPLOYMENT_TARGETS[minimum_deployment_target],
         skip_model_load=True,
     )
 


### PR DESCRIPTION
This PR enhances the GPT-2 model export functionality by adding a new option to specify the minimum deployment target for iOS. It also updates the README with instructions for using this new feature.

Main changes:
1. Updated `openai-gpt2/export-model.py`:
   - Added a `DEPLOYMENT_TARGETS` dictionary to map iOS versions to CoreML targets.
   - Introduced a new `--minimum-deployment-target` option to the `main` function.
   - Modified the `ct.convert` function to use the specified deployment target.

2. Updated `README.md`:
   - Reorganized the structure of the GPT-2 section.
   - Added an example command for exporting the GPT-2 model with the new deployment target option.

The changes allow users to specify the minimum iOS version for which the exported CoreML model should be compatible. This provides more flexibility in targeting specific iOS versions and potentially optimizing the model for newer iOS releases.

Example usage:
```sh
$ poetry run python ./openai-gpt2/export-model.py --context-size 1024 --minimum-deployment-target iOS18
```

This command exports the GPT-2 model with a context size of 1024 and sets the minimum deployment target to iOS 18.