### PR TITLE
Change input tensor dtype to `int32` in export-model.py

### DIFF
--- a/gpt-2/baseline/export-model.py
+++ b/gpt-2/baseline/export-model.py
@@ -71,8 +71,8 @@ def main(context_size: int, minimum_deployment_target: str, output: str):
 
     # convert to Core ML format
     inputs: list[ct.TensorType] = [
-        ct.TensorType(shape=input_shape, dtype=np.long, name="inputIds"),
-        ct.TensorType(shape=input_shape, dtype=np.long, name="attentionMask"),
+        ct.TensorType(shape=input_shape, dtype=np.int32, name="inputIds"),
+        ct.TensorType(shape=input_shape, dtype=np.int32, name="attentionMask"),
     ]
 
     outputs: list[ct.TensorType] = [ct.TensorType(dtype=np.float16, name="logits")]


### PR DESCRIPTION
This PR updates the input tensor data types in the `export-model.py` file for the GPT-2 baseline model export process.

Main changes:
- Modified the `dtype` of input tensors `inputIds` and `attentionMask` from `np.long` to `np.int32`.

Reason for changes:
The change from `np.long` to `np.int32` for input tensor data types is likely to ensure compatibility with Core ML's expected input formats or to optimize memory usage. This modification affects how the model processes input data during the conversion to Core ML format.